### PR TITLE
Improve Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.vscode
 /.vagrant
 .phpunit.result.cache
-.laracon-schedule
+.laravel-schedule

--- a/app/Commands/SchedulingCommand.php
+++ b/app/Commands/SchedulingCommand.php
@@ -126,7 +126,7 @@ class SchedulingCommand extends Command
                 $this->line('Please enter your "sudo" password so we can retrieve your timezone:');
                 return ltrim(exec('sudo systemsetup -gettimezone', $_, $exitCode), 'Time Zone: ');
             case Str::contains(php_uname('s'), 'Linux'):
-                return exec('date +%Z');
+                return exec('date +%Z,', $_, $exitCode);
             default:
                 abort(401, 'Only Mac OS and Linux are supported at this time.');
         }

--- a/app/Commands/SchedulingCommand.php
+++ b/app/Commands/SchedulingCommand.php
@@ -105,7 +105,7 @@ class SchedulingCommand extends Command
         if (! $disk->exists('.laravel-schedule')) {
             $timeZone = $this->getSystemTimeZone($exitCode);
 
-            if ($exitCode > 0) {
+            if ($exitCode > 0 || $timeZone === '') {
                 abort(500, 'Unable to retrieve timezone');
             }
 
@@ -126,7 +126,7 @@ class SchedulingCommand extends Command
                 $this->line('Please enter your "sudo" password so we can retrieve your timezone:');
                 return ltrim(exec('sudo systemsetup -gettimezone', $_, $exitCode), 'Time Zone: ');
             case Str::contains(php_uname('s'), 'Linux'):
-                return ltrim(exec('cat /etc/timezone'));
+                return exec('date +%Z');
             default:
                 abort(401, 'Only Mac OS and Linux are supported at this time.');
         }

--- a/app/Commands/SchedulingCommand.php
+++ b/app/Commands/SchedulingCommand.php
@@ -126,7 +126,7 @@ class SchedulingCommand extends Command
                 $this->line('Please enter your "sudo" password so we can retrieve your timezone:');
                 return ltrim(exec('sudo systemsetup -gettimezone', $_, $exitCode), 'Time Zone: ');
             case Str::contains(php_uname('s'), 'Linux'):
-                return exec('date +%Z,', $_, $exitCode);
+                return exec('date +%Z', $_, $exitCode);
             default:
                 abort(401, 'Only Mac OS and Linux are supported at this time.');
         }


### PR DESCRIPTION
Love this little tool, Nuno! :grin: 

However, `/etc/timezone` doesn't exist on Fedora (and presumably others), so `laracon-schedule` fails.

I have updated this to use the GNU coreutils `date` command, which should be more universal (@tonysm I'd love if you could test this on your system, after removing the `.laravel-schedule` cache file).

Additionally, the exit code wasn't being captured on Linux, so it wasn't failing gracefully and was writing an empty `.laravel-schedule` file that broke future attempts to run it even after fixing the underlying issue. So, I've tweaked the error handling a little.

Finally, it seems the `.gitignore` was ignoring the wrong cache file. I preferred the naming in the `.gitignore` file, but seeing as it's already been written and we don't want to prompt sudo again, I kept the other naming.